### PR TITLE
Merge upstream changes localy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+  - amd64
+  - ppc64le
+  
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ arch:
 language: go
 
 go:
-  - 1.2.1
+  - 1.13

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Process List Library for Go
+# Process List Library for Go [![GoDoc](https://godoc.org/github.com/mitchellh/go-ps?status.png)](https://godoc.org/github.com/mitchellh/go-ps)
 
 go-ps is a library for Go that implements OS-specific APIs to list and
 manipulate processes in a platform-safe way. The library can find and

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mitchellh/go-ps
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mitchellh/go-ps
+module github.com/goss-org/go-ps
 
 go 1.13

--- a/process_freebsd.go
+++ b/process_freebsd.go
@@ -1,4 +1,4 @@
-// +build freebsd,amd64
+// +build freebsd
 
 package ps
 

--- a/process_unix.go
+++ b/process_unix.go
@@ -56,7 +56,7 @@ func processes() ([]Process, error) {
 
 	results := make([]Process, 0, 50)
 	for {
-		fis, err := d.Readdir(10)
+		names, err := d.Readdirnames(10)
 		if err == io.EOF {
 			break
 		}
@@ -64,14 +64,8 @@ func processes() ([]Process, error) {
 			return nil, err
 		}
 
-		for _, fi := range fis {
-			// We only care about directories, since all pids are dirs
-			if !fi.IsDir() {
-				continue
-			}
-
+		for _, name := range names {
 			// We only care if the name starts with a numeric
-			name := fi.Name()
 			if name[0] < '0' || name[0] > '9' {
 				continue
 			}


### PR DESCRIPTION
The upstream project has some commits missing from this fork.  Syncing this
copy will fix the build of downstream projects relying on this fork instead of
upstream, e.g. choria which currently [breaks on i386] because of the lack of
32d76597b274fe874d3e8e89be19315b7b713207.

[breaks on i386]:https://pkg-status.freebsd.org/beefy13/data/131i386-quarterly/aac384af6dc4/logs/choria-0.27.0_1.log
